### PR TITLE
added vimrc keybind imitation file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ operator-pending state (``o``, inherits from motion state):
      - with ``t-f-j`` rotation
 
    * - ``t``, ``T``
-     - ``f``, ``f``
+     - ``f``, ``F``
      - jump to character
      - ``mnvo``
      - yes

--- a/example.vimrc
+++ b/example.vimrc
@@ -1,0 +1,31 @@
+" rough translation of emacs binds to vimrc binds
+
+noremap h h
+noremap n j
+noremap e k
+noremap i l
+
+noremap k n
+noremap K N
+noremap u i
+noremap U I
+noremap l u
+noremap N J
+noremap E K
+noremap u i
+
+" (setq evil-colemak-basics-rotate-t-f-j t) 
+" default
+
+noremap f e
+noremap F E
+noremap t f
+noremap T F
+noremap j t
+noremap J T
+
+" (setq evil-colemak-basics-rotate-t-f-j nil) 
+" disable the above bindings, uncomment below
+
+" noremap j e
+" noremap J E


### PR DESCRIPTION
Adds #6 as discussed. There may be some edge cases, but every bind in the readme seems to work correctly.
Also fixes a type in readme I think, correct me if it was right before!